### PR TITLE
Fix AI car configuration mismatch for interior and wheels

### DIFF
--- a/services/ai-feature/src/server.js
+++ b/services/ai-feature/src/server.js
@@ -28,38 +28,51 @@ app.post("/recommend", async (req, res) => {
   }
 
   try {
-    // Fetch all available options from services in parallel
-    const [modelsRes, productsRes, colorsRes, wheelsRes, interiorsRes] = await Promise.all([
-      fetch(`${CONFIGURATOR_URL}/models`),
-      fetch(`${MERCH_URL}/products`),
-      fetch(`${CONFIGURATOR_URL}/options/colors`),
-      fetch(`${CONFIGURATOR_URL}/options/wheels`),
-      fetch(`${CONFIGURATOR_URL}/options/interiors`),
-    ]);
-    const models    = await modelsRes.json();
-    const products  = await productsRes.json();
-    const colors    = colorsRes.ok    ? await colorsRes.json()    : [];
-    const wheels    = wheelsRes.ok    ? await wheelsRes.json()    : [];
-    const interiors = interiorsRes.ok ? await interiorsRes.json() : [];
-
     const formatPrice = (price) => price > 0 ? ` (+${price} €)` : "";
 
-    const modelList    = models.map((m) => `- ${m.code} (${m.name} ${m.packageName}, ab ${m.basePrice} €)`).join("\n");
-    const colorList    = colors.map((c) => `- ${c.name}${formatPrice(c.price)}`).join("\n");
-    const wheelsList   = wheels.map((w) => `- ${w.name}${formatPrice(w.price)}`).join("\n");
-    const interiorList = interiors.map((i) => `- ${i.name}${formatPrice(i.price)}`).join("\n");
-    const productList  = products.map((p) => `- ID ${p.id}: ${p.name} ${p.color || ""} (${p.price} €)`).join("\n");
+    // Fetch models and products first
+    const [modelsRes, productsRes] = await Promise.all([
+      fetch(`${CONFIGURATOR_URL}/models`),
+      fetch(`${MERCH_URL}/products`),
+    ]);
+    const models   = await modelsRes.json();
+    const products = await productsRes.json();
 
-    const optionalSections = [
-      colorList    ? `Verfügbare Lackierungen:\n${colorList}`         : null,
-      wheelsList   ? `Verfügbare Felgen:\n${wheelsList}`              : null,
-      interiorList ? `Verfügbare Innenausstattungen:\n${interiorList}` : null,
-    ].filter(Boolean).join("\n\n");
+    // Fetch model-specific options so the AI only picks valid combinations
+    const modelOptions = await Promise.all(
+      models.map(async (m) => {
+        const [colorsRes, wheelsRes, interiorsRes] = await Promise.all([
+          fetch(`${CONFIGURATOR_URL}/options/colors?modelId=${m.id}`),
+          fetch(`${CONFIGURATOR_URL}/options/wheels?modelId=${m.id}`),
+          fetch(`${CONFIGURATOR_URL}/options/interiors?modelId=${m.id}`),
+        ]);
+        return {
+          model:     m,
+          colors:    colorsRes.ok    ? await colorsRes.json()    : [],
+          wheels:    wheelsRes.ok    ? await wheelsRes.json()    : [],
+          interiors: interiorsRes.ok ? await interiorsRes.json() : [],
+        };
+      })
+    );
+
+    const modelList = modelOptions.map(({ model, colors, wheels, interiors }) => {
+      const colorStr    = colors.map((c) => `    - ${c.name}${formatPrice(c.price)}`).join("\n");
+      const wheelsStr   = wheels.map((w) => `    - ${w.name}${formatPrice(w.price)}`).join("\n");
+      const interiorStr = interiors.map((i) => `    - ${i.name}${formatPrice(i.price)}`).join("\n");
+      return [
+        `- ${model.code} (${model.name} ${model.packageName}, ab ${model.basePrice} €)`,
+        colorStr    ? `  Farben:\n${colorStr}`          : null,
+        wheelsStr   ? `  Felgen:\n${wheelsStr}`         : null,
+        interiorStr ? `  Interieur:\n${interiorStr}`    : null,
+      ].filter(Boolean).join("\n");
+    }).join("\n\n");
+
+    const productList = products.map((p) => `- ID ${p.id}: ${p.name} ${p.color || ""} (${p.price} €)`).join("\n");
 
     const systemPrompt = `Du bist ein persönlicher BMW-Berater. Der Nutzer beschreibt dir im Freitext wer er ist — Beruf, Alltag, Hobbys, Stil, Lebensumstände. Deine Aufgabe:
 
 1. Analysiere die Persönlichkeit und den Lifestyle des Nutzers aus seinem Text.
-2. Wähle GENAU EINE vollständige Fahrzeugkonfiguration aus den unten gelisteten verfügbaren Optionen. Nutze ausschließlich Werte, die exakt in der jeweiligen Liste stehen — erfinde nichts.
+2. Wähle GENAU EINE vollständige Fahrzeugkonfiguration. Nutze ausschließlich Farben, Felgen und Interieur die beim jeweiligen Modell gelistet sind — erfinde nichts und wähle keine Optionen eines anderen Modells.
 3. Wähle 1-3 passende Merchandise-Produkte, die zum beschriebenen Lifestyle passen.
 
 Regeln für das "text"-Feld:
@@ -67,10 +80,8 @@ Regeln für das "text"-Feld:
 - Begründe persönlich WARUM diese Konfiguration zu genau diesem Nutzer passt. Beziehe dich konkret auf Details, die der Nutzer genannt hat.
 - Kein Marketing-Sprech, keine Aufzählung von Features — sondern persönliches Matching.
 
-Verfügbare Automodelle:
+Verfügbare Automodelle mit ihren Optionen:
 ${modelList}
-
-${optionalSections}
 
 Verfügbare Merchandise-Produkte:
 ${productList}`;

--- a/web/views/car-configurator.ejs
+++ b/web/views/car-configurator.ejs
@@ -377,6 +377,7 @@
 
   function normalizeText(value) {
     return String(value || "")
+      .replace(/ä/gi, "ae").replace(/ö/gi, "oe").replace(/ü/gi, "ue")
       .normalize("NFKD")
       .replace(/[̀-ͯ]/g, "")
       .replace(/ß/g, "ss")
@@ -420,7 +421,8 @@
   function getWheelsSlug(wheels) { return inferWheelsSlug(wheels ? wheels.name : ""); }
 
   function matchesSlug(actualSlug, expectedSlug) {
-    return normalizeText(actualSlug).toLowerCase() === normalizeText(expectedSlug).toLowerCase();
+    const norm = (s) => normalizeText(s).toLowerCase().replace(/\s+/g, "");
+    return norm(actualSlug) === norm(expectedSlug);
   }
 
   function colorFromName(name) {
@@ -458,7 +460,11 @@
 
   function findOptionBySlug(options, expectedSlug, getSlug) {
     if (!expectedSlug) return null;
-    return options.find((option) => matchesSlug(getSlug(option), expectedSlug)) || null;
+    const norm = (s) => normalizeText(s).toLowerCase().replace(/\s+/g, "");
+    const normExpected = norm(expectedSlug);
+    return options.find((option) =>
+      norm(getSlug(option)) === normExpected || norm(option.name) === normExpected
+    ) || null;
   }
 
   function getCurrentSelectionSlugs() {


### PR DESCRIPTION
- Fetch model-specific options in AI service so only valid combinations per model are suggested
- Expand umlauts before slug comparison to match DB names
- Also match on raw option name in findOptionBySlug as fallback

Closes #73 