### PR TITLE
Separate MySQL schemas for merch-shop and car-configurator

### DIFF
--- a/.env
+++ b/.env
@@ -4,9 +4,6 @@ APP_ENV=development
 # Database
 MYSQL_HOST=mysql
 MYSQL_PORT=3306
-# Schema names are fixed and service-owned:
-# - merch-shop uses bmw_merch_shop
-# - car-configurator uses bmw_car_configurator
 MYSQL_USER=bmw_user
 MYSQL_PASSWORD=change_me
 MYSQL_ROOT_PASSWORD=change_me_root
@@ -25,7 +22,7 @@ MINIO_BUCKET=configurator-images
 # Local default: http://localhost:9000
 # LAN example: http://192.168.178.20:9000
 # GitHub Codespaces example: https://<codespace-name>-9000.app.github.dev
-MINIO_PUBLIC_URL=http://localhost:9000
+MINIO_PUBLIC_URL=minio
 
 # External APIs
 GEMINI_API_KEY=replace_me

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ APP_ENV=development
 # Database
 MYSQL_HOST=mysql
 MYSQL_PORT=3306
-MYSQL_DATABASE=bmw_app
+MYSQL_DATABASE_MERCH_SHOP=bmw_merch_shop
+MYSQL_DATABASE_CAR_CONFIGURATOR=bmw_car_configurator
 MYSQL_USER=bmw_user
 MYSQL_PASSWORD=change_me
 MYSQL_ROOT_PASSWORD=change_me_root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,8 @@ services:
       CODESPACE_NAME: ${CODESPACE_NAME:-}
       MINIO_PUBLIC_URL: ${MINIO_PUBLIC_URL:-}
     depends_on:
-      mysql:
-        condition: service_healthy
+      mysql-seed:
+        condition: service_completed_successfully
 
   merch-shop:
     build:
@@ -64,8 +64,8 @@ services:
       CODESPACE_NAME: ${CODESPACE_NAME:-}
       MINIO_PUBLIC_URL: ${MINIO_PUBLIC_URL:-}
     depends_on:
-      mysql:
-        condition: service_healthy
+      mysql-seed:
+        condition: service_completed_successfully
 
   shopping-cart:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,6 @@ services:
     image: mysql:8.4.8
     env_file: .env
     environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
@@ -122,8 +121,9 @@ services:
       - ./infrastructure/mysql/init:/seed:ro
     entrypoint: >
       /bin/sh -c "
-      mysql -h mysql -u root -p${MYSQL_ROOT_PASSWORD} ${MYSQL_DATABASE} < /seed/01_merch_shop.sql &&
-      mysql -h mysql -u root -p${MYSQL_ROOT_PASSWORD} ${MYSQL_DATABASE} < /seed/02_car_configurator.sql
+      mysql -h mysql -u root -p${MYSQL_ROOT_PASSWORD} < /seed/01_merch_shop.sql &&
+      mysql -h mysql -u root -p${MYSQL_ROOT_PASSWORD} < /seed/02_car_configurator.sql &&
+      mysql -h mysql -u root -p${MYSQL_ROOT_PASSWORD} -e \"CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}'; GRANT ALL PRIVILEGES ON bmw_merch_shop.* TO '${MYSQL_USER}'@'%'; GRANT ALL PRIVILEGES ON bmw_car_configurator.* TO '${MYSQL_USER}'@'%'; FLUSH PRIVILEGES;\"
       "
 
   redis:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,8 +194,9 @@ MinIO stores pre-generated configurator and merchandise images. It is used becau
 
 - `car-configurator` owns the schema `bmw_car_configurator` (models, options, configurations, prices, image keys).
 - `merch-shop` owns the schema `bmw_merch_shop` (merchandise products).
+- Both schema names are fixed architecture constants and must not be configured via environment variables.
 - Services must not query tables owned by other services directly.
-- Local development may still run one shared MySQL instance in Docker Compose, but ownership is enforced logically by separate schemas and service-specific environment variables.
+- Local development may still run one shared MySQL instance in Docker Compose, but ownership is enforced logically by separate schemas with fixed names.
 
 ## 6. External Integrations
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,6 +190,13 @@ Redis stores shopping cart state. It is used because the cart is session-oriente
 
 MinIO stores pre-generated configurator and merchandise images. It is used because these images are binary assets rather than relational records.
 
+### 5.4 Database Ownership
+
+- `car-configurator` owns the schema `bmw_car_configurator` (models, options, configurations, prices, image keys).
+- `merch-shop` owns the schema `bmw_merch_shop` (merchandise products).
+- Services must not query tables owned by other services directly.
+- Local development may still run one shared MySQL instance in Docker Compose, but ownership is enforced logically by separate schemas and service-specific environment variables.
+
 ## 6. External Integrations
 
 ### 6.1 Gemini API

--- a/infrastructure/mysql/init/01_merch_shop.sql
+++ b/infrastructure/mysql/init/01_merch_shop.sql
@@ -1,4 +1,5 @@
-USE bmw_app;
+CREATE DATABASE IF NOT EXISTS bmw_merch_shop CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE bmw_merch_shop;
 
 SET NAMES utf8mb4;
 

--- a/infrastructure/mysql/init/02_car_configurator.sql
+++ b/infrastructure/mysql/init/02_car_configurator.sql
@@ -1,4 +1,5 @@
-USE bmw_app;
+CREATE DATABASE IF NOT EXISTS bmw_car_configurator CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE bmw_car_configurator;
 
 SET NAMES utf8mb4;
 

--- a/services/car-configurator/src/server.js
+++ b/services/car-configurator/src/server.js
@@ -9,7 +9,7 @@ const pool = mysql.createPool({
   port: process.env.MYSQL_PORT || 3306,
   user: process.env.MYSQL_USER || "bmw_user",
   password: process.env.MYSQL_PASSWORD || "change_me",
-  database: process.env.MYSQL_DATABASE_CAR_CONFIGURATOR || "bmw_car_configurator",
+  database: "bmw_car_configurator",
   waitForConnections: true,
   connectionLimit: 10,
 });

--- a/services/car-configurator/src/server.js
+++ b/services/car-configurator/src/server.js
@@ -9,7 +9,7 @@ const pool = mysql.createPool({
   port: process.env.MYSQL_PORT || 3306,
   user: process.env.MYSQL_USER || "bmw_user",
   password: process.env.MYSQL_PASSWORD || "change_me",
-  database: process.env.MYSQL_DATABASE || "bmw_app",
+  database: process.env.MYSQL_DATABASE_CAR_CONFIGURATOR || "bmw_car_configurator",
   waitForConnections: true,
   connectionLimit: 10,
 });

--- a/services/merch-shop/src/server.js
+++ b/services/merch-shop/src/server.js
@@ -9,7 +9,7 @@ const dbConfig = {
   port: process.env.MYSQL_PORT || 3306,
   user: process.env.MYSQL_USER || "bmw_user",
   password: process.env.MYSQL_PASSWORD || "change_me",
-  database: process.env.MYSQL_DATABASE_MERCH_SHOP || "bmw_merch_shop",
+  database: "bmw_merch_shop",
   charset: "utf8mb4",
 };
 

--- a/services/merch-shop/src/server.js
+++ b/services/merch-shop/src/server.js
@@ -9,7 +9,7 @@ const dbConfig = {
   port: process.env.MYSQL_PORT || 3306,
   user: process.env.MYSQL_USER || "bmw_user",
   password: process.env.MYSQL_PASSWORD || "change_me",
-  database: process.env.MYSQL_DATABASE || "bmw_app",
+  database: process.env.MYSQL_DATABASE_MERCH_SHOP || "bmw_merch_shop",
   charset: "utf8mb4",
 };
 


### PR DESCRIPTION
## Summary
- split the MySQL ownership so merch-shop and car-configurator use separate schemas
- update env, docker-compose, and seed scripts to create and grant access to `bmw_merch_shop` and `bmw_car_configurator`
- document the ownership rule and local single-MySQL simplification

## Verification
- Docker Compose restart and schema verification completed
- both services respond on their `/health` endpoints
- merch-shop `/products` and car-configurator `/models` return 200