### PR TITLE
fix(configurator): render blue preview image

### DIFF
--- a/services/car-configurator/src/server.js
+++ b/services/car-configurator/src/server.js
@@ -20,7 +20,11 @@ function trimTrailingSlash(value) {
 
 function resolveMinioPublicBaseUrl() {
   if (process.env.MINIO_PUBLIC_URL) {
-    return trimTrailingSlash(process.env.MINIO_PUBLIC_URL);
+    const configuredUrl = trimTrailingSlash(process.env.MINIO_PUBLIC_URL);
+    if (/^https?:\/\//i.test(configuredUrl) || configuredUrl.startsWith("/")) {
+      return configuredUrl;
+    }
+    return `/${configuredUrl}`;
   }
 
   return "/minio";

--- a/services/car-configurator/test/preview-images.test.js
+++ b/services/car-configurator/test/preview-images.test.js
@@ -1,0 +1,23 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const apiBase = process.env.CONFIGURATOR_TEST_API_BASE || "http://127.0.0.1:3000/api/configurator";
+
+test("calculated preview image URLs are absolute site paths", async () => {
+  const response = await fetch(`${apiBase}/configuration/calculate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      modelId: 2,
+      colorId: 4,
+      interiorId: 13,
+      wheelsId: 2,
+    }),
+  });
+
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+
+  assert.match(payload.previewImages.front, /^\/minio\/configurator-images\/configurator\/6_front\.jpg$/);
+});


### PR DESCRIPTION
## Summary
- Normalize configured MinIO public URLs to absolute site paths.
- Fix configurator preview images on nested routes such as BMW X5 Blue.
- Add a regression test for the X5 Blue preview image URL.

## Root cause
When MINIO_PUBLIC_URL was configured as minio, the configurator API returned image URLs like minio/configurator-images/.... On nested configurator URLs, browsers resolved that as a relative path, so the selected Blue preview image could not load.

## Verification
- 
ode --test services/car-configurator/test/preview-images.test.js
- Manual API/image check: X5 Blue preview URL returns /minio/configurator-images/configurator/6_front.jpg, and that image returns HTTP 200 via http://127.0.0.1:3000.
