### PR TITLE
Redesign AI feature page with premium dark editorial layout

### DIFF
--- a/web/views/ai-feature.ejs
+++ b/web/views/ai-feature.ejs
@@ -1,139 +1,233 @@
+<%
+  const _minioBase = String(process.env.MINIO_PUBLIC_URL || "http://localhost:9000").replace(/\/+$/, "");
+  const _minioBucket = process.env.MINIO_BUCKET || "configurator-images";
+  const aiHeroImg = `${_minioBase}/${_minioBucket}/home/bmw_duo_4k_uhd.png`;
+%>
 <style>
   /* AI-feature-specific layout. BMW CI tokens, fonts, page-shell, site-nav,
      site-footer, section-*, .btn*, .field/.input, .card* live in
      /static/ci/bmw-ci.css. */
 
-  .ai-layout {
-    max-width: 1060px;
-    margin: 0 auto;
-    padding: 48px 20px 80px;
+  /* Float the nav over the hero image — keeps its solid dark background
+     from bmw-ci.css, same 24px gap at top, no white body bleeding through. */
+  body > nav.site-nav--solid {
+    position: absolute !important;
+    top: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    margin: 0 !important;
   }
 
-  /* ── Hero ── */
-  .hero {
-    text-align: center;
-    margin-bottom: 40px;
+  /* ── Hero: full-viewport BMW image background ── */
+  .ai-hero-section {
     position: relative;
+    width: 100%;
+    min-height: 100vh;
+    overflow: hidden;
+    background: #070b10;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
   }
-  .hero::after {
-    content: '';
-    position: absolute;
-    top: -60px; right: -80px;
-    width: 380px; height: 380px;
-    border-radius: 50%;
-    background: radial-gradient(circle, rgba(28, 105, 212, 0.10) 0%, transparent 70%);
+  .ai-hero-bg {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    object-fit: cover;
+    /* position adjusted to show the cars clearly, not the light studio floor */
+    object-position: center 42%;
+    filter: brightness(0.58) saturate(0.80);
+  }
+  .ai-hero-overlay {
+    position: absolute; inset: 0;
+    background:
+      linear-gradient(180deg, rgba(0,0,0,0.32) 0%, rgba(0,0,0,0.08) 40%, rgba(0,0,0,0.96) 100%),
+      linear-gradient(90deg, rgba(0,0,0,0.28) 0%, rgba(0,0,0,0.04) 55%, rgba(0,0,0,0.16) 100%);
     pointer-events: none;
-    z-index: 0;
   }
-  .hero > * { position: relative; z-index: 1; }
+  .ai-hero-content {
+    position: relative; z-index: 2;
+    max-width: 1060px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 80px 24px 60px;
+  }
 
-  .ai-layout h1 {
-    font-size: 2.6rem;
+  /* ── Hero text ── */
+  .hero { text-align: center; margin-bottom: 72px; }
+  .ai-hero-section h1 {
+    font-size: 2.8rem;
     font-weight: 800;
     letter-spacing: -0.035em;
-    line-height: 1.15;
+    line-height: 1.12;
     margin: 0 0 16px;
+    color: #fff;
+    text-shadow: 0 4px 28px rgba(0,0,0,0.45);
   }
   .subtitle {
-    color: var(--muted);
+    color: rgba(255,255,255,0.70);
     font-size: 1.05rem;
     max-width: 460px;
     margin: 0 auto;
   }
 
-  /* ── Input card ── */
+  /* ── Input card: frosted glass on dark image ── */
   .input-card {
-    background: var(--panel);
+    background: rgba(255,255,255,0.10);
     border-radius: 20px;
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.08);
-    border: 1px solid rgba(0,0,0,0.05);
+    box-shadow: 0 8px 48px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.14);
+    border: 1px solid rgba(255,255,255,0.18);
     overflow: hidden;
-    transition: box-shadow 0.3s ease;
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
   }
   .input-card:focus-within {
-    box-shadow: 0 0 0 2px var(--accent), 0 12px 40px rgba(0, 0, 0, 0.08);
+    border-color: rgba(28,105,212,0.75);
+    box-shadow: 0 0 0 2px rgba(28,105,212,0.28), 0 8px 48px rgba(0,0,0,0.45);
   }
   textarea {
     width: 100%; padding: 24px 24px 16px; border: none;
     font-size: 1.05rem; font-family: inherit; resize: none;
     min-height: 150px; outline: none; line-height: 1.65;
     background: transparent;
-    color: var(--ink);
+    color: #fff;
+    caret-color: #fff;
   }
+  textarea::placeholder { color: rgba(255,255,255,0.36); }
   .input-footer {
     display: flex; justify-content: flex-end; align-items: center;
     padding: 12px 20px 16px;
-    border-top: 1px solid rgba(0,0,0,0.05);
+    border-top: 1px solid rgba(255,255,255,0.10);
   }
   .send-btn {
-    padding: 11px 26px; border: none; border-radius: 999px;
-    background: var(--accent); color: #fff; font-size: 0.95rem; font-weight: 700;
+    padding: 11px 26px; border: none; border-radius: var(--radius);
+    background: var(--accent); color: #fff; font-size: 0.8rem; font-weight: 700;
     cursor: pointer; transition: all 0.25s ease; white-space: nowrap;
-    font-family: inherit;
+    font-family: inherit; letter-spacing: 0.07em; text-transform: uppercase;
   }
   .send-btn:hover:not(:disabled) { background: var(--accent-dark); transform: translateY(-1px); }
-  .send-btn:disabled { background: #cbd5e1; cursor: not-allowed; transform: none; }
+  .send-btn:disabled { background: rgba(255,255,255,0.18); color: rgba(255,255,255,0.42); cursor: not-allowed; transform: none; }
 
-  /* ── Feedback ── */
-  .spinner { display: none; text-align: center; padding: 36px; font-weight: 600; color: var(--accent); font-size: 0.95rem; letter-spacing: 0.02em; }
+  /* ── Spinner / Error (still in hero overlay area) ── */
+  .spinner {
+    display: none; text-align: center; padding: 24px 36px;
+    font-weight: 600; color: rgba(255,255,255,0.82); font-size: 0.95rem; letter-spacing: 0.02em;
+    position: relative; z-index: 2;
+  }
   .spinner.visible { display: block; animation: pulse 1.5s infinite; }
   @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-  .error { color: #dc2626; font-weight: 600; text-align: center; margin-top: 16px; font-size: 0.9rem; }
+  .error {
+    color: #fca5a5; font-weight: 600; text-align: center;
+    margin-top: 16px; font-size: 0.9rem;
+    position: relative; z-index: 2;
+  }
 
-  /* ── Result ── */
-  .result { display: none; margin-top: 32px; }
-  .result.visible { display: block; animation: fadeUp 0.45s ease both; }
-  @keyframes fadeUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+  /* ── Results area: continues hero dark tone, fades to light ── */
+  .ai-results {
+    max-width: none;
+    margin: -2px 0 0;
+    padding: 0;
+    background: linear-gradient(to bottom,
+      #000 0px,
+      #0f172a 200px,
+      #0f172a 600px,
+      #f0f4f8 800px
+    );
+  }
 
-  /* ── Car reveal ── */
+  /* ── Result wrapper ── */
+  .result { display: none; max-width: 1060px; margin: 0 auto; padding: 0 20px 80px; }
+  .result.visible { display: block; animation: fadeUp 0.5s ease both; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: none; } }
+
+  /* ── Car reveal: full-viewport, editorial — car is the centrepiece ── */
   .car-reveal {
-    border-radius: 20px;
-    background: linear-gradient(135deg, var(--accent-dark) 0%, var(--accent) 60%, #4a8ee0 100%);
-    color: #fff;
-    padding: 32px 32px 28px;
-    margin-bottom: 16px;
-    position: relative;
-    overflow: hidden;
+    display: flex; flex-direction: column;
+    height: calc(100vh - 80px); min-height: 520px;
+    text-align: center; color: #fff;
   }
-  .car-reveal::before {
-    content: '';
-    position: absolute; inset: 0;
-    background: radial-gradient(ellipse at 80% 50%, rgba(255,255,255,0.07) 0%, transparent 60%);
-    pointer-events: none;
-  }
+  .car-reveal-header { padding: 14px 0 12px; flex-shrink: 0; }
   .car-reveal-eyebrow {
-    font-size: 0.68rem; font-weight: 700; letter-spacing: 0.16em;
-    text-transform: uppercase; opacity: 0.65; margin-bottom: 8px;
+    font-size: 0.65rem; font-weight: 700; letter-spacing: 0.18em;
+    text-transform: uppercase; opacity: 0.45; margin-bottom: 10px;
   }
-  .car-reveal-model { font-size: 2rem; font-weight: 800; letter-spacing: -0.02em; line-height: 1.1; margin-bottom: 6px; }
-  .car-reveal-color { font-size: 0.9rem; opacity: 0.75; margin-bottom: 24px; }
-  .car-reveal-cta {
-    display: flex; align-items: center; justify-content: space-between;
-    padding: 14px 22px;
-    background: rgba(255,255,255,0.18); border: 1px solid rgba(255,255,255,0.35);
-    border-radius: 14px; color: #fff; text-decoration: none;
-    font-weight: 700; font-size: 0.95rem;
-    transition: background 0.2s ease; backdrop-filter: blur(4px);
+  .car-reveal-model {
+    font-size: 4.8rem; font-weight: 800; letter-spacing: -0.04em;
+    line-height: 1; margin-bottom: 16px;
   }
-  .car-reveal-cta:hover { background: rgba(255,255,255,0.28); }
-  .car-reveal-content { display: flex; align-items: center; gap: 24px; position: relative; }
-  .car-reveal-text { flex: 1; min-width: 0; }
+  .car-reveal-specs {
+    display: grid; grid-template-columns: 1fr 1fr 1fr;
+    width: 100%; max-width: 700px;
+    margin: 0 auto;
+  }
+  .car-reveal-spec {
+    display: flex; flex-direction: column; align-items: center; gap: 5px;
+    padding: 0 16px;
+    border-right: 1px solid rgba(255,255,255,0.12);
+  }
+  .car-reveal-spec:last-child { border-right: none; }
+  .car-reveal-spec-label {
+    font-size: 0.62rem; letter-spacing: 0.12em;
+    text-transform: uppercase; opacity: 0.48;
+  }
+  .car-reveal-spec-value {
+    font-size: 0.9rem; font-weight: 600; color: #fff;
+    text-align: center; word-break: break-word;
+  }
+
+  /* full-width cream image — the car dominates the screen */
   .car-reveal-image-wrap {
-    flex-shrink: 0; width: 340px; height: 230px;
+    width: calc(100% + 40px); flex: 1; min-height: 180px;
+    background: #eee9e2;
+    border-radius: 0;
     display: flex; align-items: center; justify-content: center;
+    position: relative; overflow: hidden;
+    margin: 0 -20px 0;
   }
   .car-reveal-image-wrap img {
-    width: 100%; height: 100%; object-fit: contain;
-    filter: drop-shadow(0 8px 24px rgba(0,0,0,0.45));
-    animation: carSlideIn 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+    width: 100%; height: 100%; object-fit: cover; object-position: center 40%;
+    animation: carRevealIn 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
   }
-  @keyframes carSlideIn { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: none; } }
+  @keyframes carRevealIn {
+    from { opacity: 0; transform: scale(0.96); }
+    to   { opacity: 1; transform: none; }
+  }
   .car-img-shimmer {
-    width: 100%; height: 100%; border-radius: 12px;
-    background: linear-gradient(90deg, rgba(255,255,255,0.05) 25%, rgba(255,255,255,0.14) 50%, rgba(255,255,255,0.05) 75%);
+    width: 60%; height: 60%;
+    background: linear-gradient(90deg, #e2ddd6 25%, #f0ece6 50%, #e2ddd6 75%);
     background-size: 200% 100%; animation: shimmer 1.4s infinite;
+    border-radius: 8px;
   }
   @keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+
+  .car-reveal-footer { flex-shrink: 0; padding: 18px 0 22px; }
+  .car-reveal-btns {
+    display: flex; flex-direction: column; align-items: center; gap: 14px;
+  }
+  /* merch trigger: subtle text link, sits on the light gradient zone */
+  .car-reveal .merch-trigger-btn {
+    background: none; border: none;
+    color: rgba(15, 23, 42, 0.45);
+    font-size: 0.75rem; font-weight: 600;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    cursor: pointer; font-family: inherit;
+    padding: 4px 0;
+    display: inline-flex; align-items: center; gap: 6px;
+    transition: color 0.2s;
+  }
+  .car-reveal .merch-trigger-btn:hover {
+    color: rgba(15, 23, 42, 0.75);
+  }
+  .car-reveal-cta {
+    display: inline-flex; align-items: center; gap: 10px;
+    padding: 15px 44px;
+    background: var(--accent); border: none;
+    border-radius: var(--radius); color: #fff; text-decoration: none;
+    font-weight: 700; font-size: 0.9rem;
+    letter-spacing: 0.07em; text-transform: uppercase;
+    transition: background 0.2s ease, transform 0.2s ease;
+  }
+  .car-reveal-cta:hover { background: var(--accent-dark); transform: translateY(-2px); }
 
   /* ── Why toggle ── */
   .why-toggle {
@@ -149,17 +243,12 @@
   .why-toggle:hover { color: var(--accent); border-color: var(--accent); }
   .why-arrow { margin-left: auto; font-size: 0.75rem; transition: transform 0.25s ease; }
   .why-toggle.open .why-arrow { transform: rotate(180deg); }
-
   .why-panel {
     max-height: 0; overflow: hidden;
     transition: max-height 0.35s ease, opacity 0.3s ease;
-    opacity: 0;
-    margin-top: -20px; margin-bottom: 0;
+    opacity: 0; margin-top: -20px; margin-bottom: 0;
   }
-  .why-panel.open {
-    max-height: 300px; opacity: 1;
-    margin-bottom: 24px;
-  }
+  .why-panel.open { max-height: 300px; opacity: 1; margin-bottom: 24px; }
   .why-panel-inner {
     padding: 20px 24px;
     background: var(--panel); border: 1px solid rgba(0,0,0,0.05);
@@ -167,11 +256,41 @@
     font-size: 0.95rem; color: #334155; line-height: 1.7;
   }
 
-  /* ── Merch section ── */
+  /* ── Merch trigger button ── */
+  .merch-trigger {
+    text-align: center;
+    padding: 36px 0 8px;
+  }
+  .merch-trigger-btn {
+    display: inline-flex; align-items: center; gap: 10px;
+    padding: 14px 36px;
+    background: transparent;
+    border: 1px solid rgba(0,0,0,0.18);
+    border-radius: var(--radius);
+    color: var(--ink);
+    font-size: 0.8rem; font-weight: 700;
+    letter-spacing: 0.07em; text-transform: uppercase;
+    cursor: pointer; font-family: inherit;
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+  }
+  .merch-trigger-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: rgba(28,105,212,0.05);
+  }
+
+  /* ── Merch section: hidden by default, expands on trigger ── */
   .merch-section {
-    margin-top: 28px;
-    padding-top: 24px;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: max-height 0.7s ease, opacity 0.5s ease;
+    margin-top: 28px; padding-top: 24px;
     border-top: 1px solid rgba(0,0,0,0.09);
+  }
+  .merch-section.expanded {
+    max-height: 4000px;
+    opacity: 1;
   }
   .merch-section-header { margin-bottom: 24px; }
   .merch-section-eyebrow {
@@ -215,28 +334,19 @@
     transition: transform 0.3s ease;
   }
   .merch-product-card:hover .merch-product-img img { transform: scale(1.06); }
-  .merch-product-img-fallback {
-    font-size: 1.4rem; font-weight: 800; color: var(--accent-dark);
-  }
-  .merch-product-body {
-    padding: 12px 14px 14px;
-    display: flex; flex-direction: column; gap: 10px; flex: 1;
-  }
+  .merch-product-img-fallback { font-size: 1.4rem; font-weight: 800; color: var(--accent-dark); }
+  .merch-product-body { padding: 12px 14px 14px; display: flex; flex-direction: column; gap: 10px; flex: 1; }
   .merch-product-name {
     font-size: 0.88rem; font-weight: 700; color: var(--ink);
     line-height: 1.3;
     display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
   }
-  .merch-product-price {
-    font-size: 1rem; font-weight: 800; color: var(--accent);
-  }
+  .merch-product-price { font-size: 1rem; font-weight: 800; color: var(--accent); }
   .merch-product-link { display: block; text-decoration: none; color: inherit; }
   .merch-product-name a { text-decoration: none; color: inherit; }
   .merch-product-name a:hover { color: var(--accent); }
 
-  .merch-qty-row {
-    display: flex; align-items: center; gap: 8px; margin-top: auto;
-  }
+  .merch-qty-row { display: flex; align-items: center; gap: 8px; margin-top: auto; }
   .merch-qty-input {
     width: 56px; padding: 9px 8px;
     border: 1px solid #e2e8f0; border-radius: 8px;
@@ -246,7 +356,6 @@
     transition: border-color 0.18s; flex-shrink: 0;
   }
   .merch-qty-input:focus { border-color: var(--accent); }
-
   .add-to-cart-btn {
     flex: 1; padding: 9px 12px;
     background: var(--accent); color: #fff; border: none;
@@ -259,34 +368,39 @@
   .add-to-cart-btn:disabled { opacity: 0.6; cursor: not-allowed; }
 
   @media (max-width: 640px) {
-    .ai-layout h1 { font-size: 2rem; }
-    .hero::after { width: 200px; height: 200px; top: -20px; right: -30px; }
-    .car-reveal { padding: 22px; }
-    .car-reveal-content { flex-direction: column-reverse; gap: 12px; }
-    .car-reveal-image-wrap { width: 100%; height: 180px; }
-    .car-reveal-model { font-size: 1.6rem; }
+    .ai-hero-content { padding: 100px 16px 80px; }
+    .ai-hero-section h1 { font-size: 2rem; }
+    .car-reveal { height: auto; }
+    .car-reveal-model { font-size: 3rem; }
+    .car-reveal-image-wrap { height: 240px; flex: none; margin: 0 -16px 0; width: calc(100% + 32px); }
+    .car-reveal-footer { padding: 14px 0 18px; }
+    .car-reveal-cta { padding: 13px 28px; font-size: 0.85rem; }
     .merch-grid { grid-template-columns: repeat(2, 1fr); gap: 12px; }
     .input-footer { flex-direction: column; align-items: stretch; }
     .send-btn { width: 100%; text-align: center; }
   }
 </style>
 
-<div class="ai-layout">
-  <div class="hero">
-    <h1>Dein BMW, auf dich abgestimmt.</h1>
-    <p class="subtitle">Beschreibe deinen Alltag. Wir finden deinen BMW.</p>
-  </div>
-
-  <div class="input-card">
-    <textarea id="prompt" placeholder="Ich arbeite als Architekt, pendle täglich in die Stadt und fahre am Wochenende gern durch die Berge..."></textarea>
-    <div class="input-footer">
-      <button class="send-btn" id="sendBtn">Konfiguration finden</button>
+<div class="ai-hero-section">
+  <img class="ai-hero-bg" src="<%= aiHeroImg %>" alt="" aria-hidden="true" loading="eager">
+  <div class="ai-hero-overlay"></div>
+  <div class="ai-hero-content">
+    <div class="hero">
+      <h1>Dein BMW, auf dich abgestimmt.</h1>
+      <p class="subtitle">Beschreibe deinen Alltag. Wir finden deinen BMW.</p>
     </div>
+    <div class="input-card">
+      <textarea id="prompt" placeholder="Ich arbeite als Architekt, pendle täglich in die Stadt und fahre am Wochenende gern durch die Berge..."></textarea>
+      <div class="input-footer">
+        <button class="send-btn" id="sendBtn">Konfiguration finden</button>
+      </div>
+    </div>
+    <div class="error" id="errorMsg"></div>
+    <div class="spinner" id="spinner">Analysiere deinen Lifestyle ...</div>
   </div>
+</div>
 
-  <div class="error" id="errorMsg"></div>
-  <div class="spinner" id="spinner">Analysiere deinen Lifestyle ...</div>
-
+<div class="ai-results">
   <div class="result" id="result">
     <div id="carReveal"></div>
     <div class="ai-text-card" id="resultText"></div>
@@ -328,28 +442,43 @@
       }
       modelLabel = carModel ? `BMW ${escapeHtml(carModel)}` : "Dein BMW";
       const colorLabel   = COLOR_DE[carColor] || escapeHtml(carColor || "");
-      const wheelsLine   = carWheels   ? `<div class="car-reveal-color">Felgen: ${escapeHtml(carWheels)}</div>`       : "";
-      const interiorLine = carInterior ? `<div class="car-reveal-color">Interieur: ${escapeHtml(carInterior)}</div>` : "";
+      const specsHtml = [
+        colorLabel ? `<span class="car-reveal-spec"><span class="car-reveal-spec-label">Farbe</span><span class="car-reveal-spec-value">${colorLabel}</span></span>` : "",
+        carWheels  ? `<span class="car-reveal-spec"><span class="car-reveal-spec-label">Felgen</span><span class="car-reveal-spec-value">${escapeHtml(carWheels)}</span></span>` : "",
+        carInterior? `<span class="car-reveal-spec"><span class="car-reveal-spec-label">Interieur</span><span class="car-reveal-spec-value">${escapeHtml(carInterior)}</span></span>` : "",
+      ].filter(Boolean).join('');
       carHtml = `
         <div class="car-reveal">
-          <div class="car-reveal-content">
-            <div class="car-reveal-text">
-              <div class="car-reveal-eyebrow">Deine Empfehlung</div>
-              <div class="car-reveal-model">${modelLabel}</div>
-              ${colorLabel ? `<div class="car-reveal-color">Farbe: ${colorLabel}</div>` : ""}
-              ${wheelsLine}
-              ${interiorLine}
+          <div class="car-reveal-header">
+            <div class="car-reveal-eyebrow">Deine Empfehlung</div>
+            <div class="car-reveal-model">${modelLabel}</div>
+            ${specsHtml ? `<div class="car-reveal-specs">${specsHtml}</div>` : ""}
+          </div>
+          <div class="car-reveal-image-wrap" id="carImgWrap">
+            <div class="car-img-shimmer"></div>
+          </div>
+          <div class="car-reveal-footer">
+            <div class="car-reveal-btns">
               <a class="car-reveal-cta" href="${escapeHtml(data.carLink)}">
-                Konfiguration ansehen &nbsp;→
+                Jetzt konfigurieren &nbsp;→
               </a>
-            </div>
-            <div class="car-reveal-image-wrap" id="carImgWrap">
-              <div class="car-img-shimmer"></div>
+              <button class="merch-trigger-btn" id="merchRevealBtn" type="button">
+                Lifestyle &amp; Merch entdecken
+                <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 9l6 6 6-6"/></svg>
+              </button>
             </div>
           </div>
         </div>`;
     }
     document.getElementById("carReveal").innerHTML = carHtml;
+
+    document.getElementById("merchRevealBtn")?.addEventListener("click", () => {
+      const section = document.querySelector(".merch-section");
+      if (section) {
+        section.classList.add("expanded");
+        setTimeout(() => section.scrollIntoView({ behavior: "smooth", block: "start" }), 80);
+      }
+    });
 
       // Async: load car image from configurator
       if (carModel) {
@@ -375,7 +504,8 @@
       </button>
       <div class="why-panel" id="whyPanel">
         <div class="why-panel-inner" id="whyText"></div>
-      </div>`;
+      </div>
+      `;
     document.getElementById("resultText").innerHTML = whyHtml;
     document.getElementById("whyText").textContent = data.text;
     document.getElementById("whyToggle").addEventListener("click", () => {
@@ -515,6 +645,10 @@
       spinner.classList.remove("visible");
       result.classList.add("visible");
       btn.disabled = false;
+      setTimeout(() => {
+        const top = result.getBoundingClientRect().top + window.scrollY - 80;
+        window.scrollTo({ top, behavior: "smooth" });
+      }, 150);
     } catch (err) {
       error.textContent = err.message;
       btn.disabled = false;
@@ -522,7 +656,7 @@
     }
   });
 
-  // ── Restore previous result on page load ──────────────────────────
+  // ── Restore previous result on page load (no auto-scroll on restore) ─
   try {
     const saved = JSON.parse(sessionStorage.getItem(STORAGE_KEY) || "null");
     if (saved?.data) {
@@ -531,4 +665,5 @@
       result.classList.add("visible");
     }
   } catch {}
+
 </script>


### PR DESCRIPTION
- Full-viewport hero with BMW duo background image and frosted glass input card
- Car reveal section fills exactly one viewport: model name, 3-column specs grid, full-bleed car image, CTAs
- Dark-to-light gradient background matching hero transition
- Nav floats over hero with solid dark background (consistent with other pages)
- Merch section hidden by default, revealed via subtle secondary CTA
- BMW CI button styles (border-radius: 8px, uppercase letter-spacing)


Closes #86 