### PR TITLE
Redesign merch shop overview and product detail pages

### DIFF
--- a/web/views/merch-product.ejs
+++ b/web/views/merch-product.ejs
@@ -2,7 +2,7 @@
   .product-page {
     width: min(1180px, calc(100% - 40px));
     margin: 0 auto;
-    padding: 30px 0 84px;
+    padding: 30px 0 48px;
   }
 
   .product-overview {
@@ -77,97 +77,83 @@
 
   .product-detail {
     display: grid;
-    grid-template-columns: minmax(0, 1.04fr) minmax(380px, 0.96fr);
-    gap: 32px;
-    align-items: start;
+    grid-template-columns: minmax(0, 1.15fr) minmax(360px, 0.85fr);
+    gap: 52px;
+    align-items: stretch;
   }
 
   .product-media {
     position: relative;
-    display: grid;
-    place-items: center;
-    min-height: 0;
-    aspect-ratio: 1 / 1;
-    padding: clamp(34px, 6vw, 72px);
-    border: 1px solid var(--line);
-    border-radius: var(--radius);
-    background: #f5f7f9;
+    height: max(440px, calc(100vh - 142px));
+    border-radius: 20px;
+    background: #eee9e2;
     overflow: hidden;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
 
   .product-media img {
-    position: relative;
-    width: min(100%, 650px);
-    max-height: 88%;
+    position: absolute;
+    inset: 0;
+    width: 100%; height: 100%;
     display: block;
-    object-fit: contain;
-    transition: transform 0.6s ease;
-  }
-
-  .product-media:hover {
-    border-color: rgba(17, 24, 39, 0.22);
-    box-shadow: 0 18px 42px rgba(16, 24, 40, 0.08);
+    object-fit: cover;
+    transition: transform 0.7s ease;
   }
 
   .product-media:hover img {
-    transform: scale(1.08);
+    transform: scale(1.06);
   }
 
   .product-panel {
     position: sticky;
     top: 102px;
-    border: 1px solid var(--line);
-    border-radius: var(--radius);
-    background: #fff;
-    padding: clamp(26px, 4vw, 34px);
-    box-shadow: 0 20px 50px rgba(16, 24, 40, 0.09);
+    padding: 8px 0;
+    background: var(--paper);
+    display: flex;
+    flex-direction: column;
   }
 
   .product-kicker {
-    margin: 0 0 10px;
+    margin: 0 0 14px;
     color: var(--accent);
-    font-size: 0.75rem;
+    font-size: 0.76rem;
     font-weight: 700;
-    letter-spacing: 0.16em;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
   }
 
   .product-panel h1 {
     margin: 0;
     color: var(--ink);
-    font-size: clamp(2rem, 4vw, 3rem);
-    font-weight: 800;
+    font-size: clamp(2.2rem, 4vw, 3.4rem);
+    font-weight: 700;
     letter-spacing: 0;
-    line-height: 1.1;
+    line-height: 1.05;
   }
 
   .product-price {
-    margin: 18px 0 0;
+    margin: 20px 0 0;
     color: var(--ink);
-    font-size: 1.65rem;
+    font-size: 2rem;
     font-weight: 800;
+    letter-spacing: -0.02em;
   }
 
   .product-description {
     max-width: 48ch;
-    margin: 22px 0 0;
+    margin: 20px 0 0;
     color: var(--muted);
     font-size: 1rem;
-    line-height: 1.55;
+    line-height: 1.6;
   }
 
   .product-meta {
-    display: inline-flex;
-    align-items: center;
-    min-height: 34px;
-    margin: 18px 0 0;
-    padding: 0 12px;
-    border: 1px solid rgba(17, 24, 39, 0.12);
-    background: #f8fafc;
-    color: var(--ink);
-    font-size: 0.9rem;
+    display: block;
+    margin: 14px 0 0;
+    color: var(--muted);
+    font-size: 0.88rem;
     font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
   }
 
   .availability-box {
@@ -224,7 +210,7 @@
   .buy-form {
     display: grid;
     gap: 18px;
-    margin-top: 30px;
+    margin-top: auto;
     padding-top: 24px;
     border-top: 1px solid var(--line);
   }
@@ -248,18 +234,23 @@
   }
 
   .size-option span {
-    min-width: 58px;
-    min-height: 48px;
+    min-width: 56px;
+    min-height: 44px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid rgba(17, 24, 39, 0.16);
-    border-radius: var(--radius);
+    border: 1.5px solid rgba(17, 24, 39, 0.14);
+    border-radius: 10px;
     background: #fff;
     color: var(--ink);
-    font-size: 0.92rem;
+    font-size: 0.88rem;
     font-weight: 700;
     cursor: pointer;
+    transition: border-color 0.18s, background 0.18s, color 0.18s;
+  }
+
+  .size-option span:hover {
+    border-color: var(--ink);
   }
 
   .size-option input:checked + span {
@@ -269,13 +260,15 @@
   }
 
   .action-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
   }
 
   .action-row .btn {
+    width: 100%;
     min-height: 54px;
+    font-size: 0.88rem;
   }
 
   .status-line {
@@ -293,24 +286,11 @@
   }
 
   @media (max-width: 860px) {
-    .product-detail,
-    .control-grid,
-    .action-row {
-      grid-template-columns: 1fr;
-    }
-
-    .product-page {
-      width: min(100% - 28px, 1180px);
-    }
-
-    .product-media {
-      aspect-ratio: 4 / 3;
-      padding: 24px;
-    }
-
-    .product-panel {
-      position: static;
-    }
+    .product-detail { grid-template-columns: 1fr; gap: 28px; }
+    .control-grid   { grid-template-columns: 1fr; }
+    .product-page   { width: min(100% - 28px, 1180px); }
+    .product-media  { height: auto; aspect-ratio: 4 / 3; border-radius: 14px; }
+    .product-panel  { position: static; padding: 0; }
   }
 </style>
 

--- a/web/views/merch-shop.ejs
+++ b/web/views/merch-shop.ejs
@@ -21,111 +21,62 @@
   .product-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 32px;
-    /* Override: merch-shop prefers square product images. */
-    --card-image-aspect: 1 / 1;
+    gap: 20px;
   }
 
-  .product-grid .card-image {
+  /* ── Merch card: full-bleed image with overlay ── */
+  .merch-card {
+    position: relative;
+    height: clamp(260px, 32vw, 380px);
+    border-radius: 12px;
+    overflow: hidden;
+    background: #f1f5f9;
+    cursor: pointer;
+    transition: transform 0.22s ease, box-shadow 0.22s ease;
+  }
+  .merch-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 16px 40px rgba(0,0,0,0.14);
+  }
+  .merch-card-img {
+    position: absolute;
+    inset: 0;
+    width: 100%; height: 100%;
+    object-fit: cover;
     transition: transform 0.6s ease;
   }
-  .product-grid .card:hover .card-image {
-    transform: scale(1.08);
-  }
+  .merch-card:hover .merch-card-img { transform: scale(1.06); }
 
-  .product-grid .card {
-    cursor: pointer;
-  }
-
-  .category-tag {
-    font-size: 0.7rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--accent);
-    margin-bottom: 8px;
-  }
-
-  .product-grid .card-body h2 {
-    font-size: 1.2rem;
-    font-weight: 700;
-    margin: 0 0 12px;
-    color: var(--ink);
-  }
-
-  .product-title-link {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .product-title-link:hover {
-    color: var(--accent);
-  }
-
-  .price {
-    font-size: 1.3rem;
-    font-weight: 800;
-    color: var(--ink);
-    margin-bottom: 16px;
-  }
-
-  .detail {
-    font-size: 0.9rem;
-    color: var(--muted);
-    margin-bottom: 20px;
-    line-height: 1.5;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  .purchase-row {
-    display: flex;
-    gap: 12px;
-    align-items: stretch;
-    margin-top: auto;
-  }
-
-  .quantity-field {
-    width: 88px;
-    border: 1px solid rgba(15, 23, 42, 0.10);
-    border-radius: 12px;
-    background: #fff;
-    padding: 0 12px;
-    font-size: 0.95rem;
-    font-weight: 700;
-    color: var(--ink);
-  }
-
-  .add-btn {
-    flex: 1;
-    padding: 14px;
-    border: none;
-    border-radius: 12px;
-    background: #f1f5f9;
-    color: var(--ink);
-    font-size: 0.95rem;
-    font-weight: 700;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    margin-top: auto;
-    font-family: inherit;
-  }
-
-  .add-btn:hover {
-    background: var(--ink);
+  .merch-card-overlay {
+    position: absolute;
+    bottom: 0; left: 0; right: 0;
+    padding: 56px 20px 20px;
+    background: linear-gradient(to top, rgba(5,10,18,0.88) 0%, rgba(5,10,18,0.42) 55%, transparent 100%);
     color: #fff;
+    transition: padding-bottom 0.25s ease;
   }
+  .merch-card:hover .merch-card-overlay { padding-bottom: 68px; }
 
-  .add-btn.success {
-    background: #10b981;
-    color: #fff;
+  .merch-card-category {
+    display: block;
+    font-size: 0.68rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.14em;
+    color: rgba(255,255,255,0.62); margin-bottom: 5px;
+  }
+  .merch-card-name {
+    font-size: 1rem; font-weight: 700;
+    margin: 0 0 5px; line-height: 1.2;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+  }
+  .merch-card-name a { color: inherit; text-decoration: none; }
+  .merch-card-price {
+    font-size: 1rem; font-weight: 800; color: rgba(255,255,255,0.9);
   }
 
   @media (max-width: 640px) {
     .shop-header h1 { font-size: 2.2rem; }
-    .product-grid { gap: 20px; }
+    .product-grid { gap: 14px; }
+    .merch-card { height: clamp(220px, 60vw, 300px); }
   }
 </style>
 
@@ -166,118 +117,33 @@
   </header>
 
   <div class="product-grid">
-    <% groupedProducts.forEach(function(group) { const primaryProduct = group.variants[0]; %>
-      <article class="card card--product" id="product-<%= primaryProduct.id %>" data-detail-url="/merch-shop/<%= primaryProduct.slug || primaryProduct.id %>">
+    <% groupedProducts.forEach(function(group) { const primaryProduct = group.variants[0]; const detailUrl = `/merch-shop/${primaryProduct.slug || primaryProduct.id}`; %>
+      <a class="merch-card" id="product-<%= primaryProduct.id %>" href="<%= detailUrl %>">
         <img
-          class="card-image product-image"
+          class="merch-card-img"
           src="<%= primaryProduct.imageUrl %>"
           alt="<%= group.displayName %>"
           loading="lazy"
         />
-        <div class="card-body">
-          <div class="category-tag"><%= primaryProduct.category %></div>
-          <h2><a class="product-title-link" href="/merch-shop/<%= primaryProduct.slug || primaryProduct.id %>"><%= group.displayName %></a></h2>
-          <div class="price"><%= parseFloat(primaryProduct.price).toLocaleString("de-DE", { style: "currency", currency: "EUR" }) %></div>
-
-          <% const displayDescription = getDisplayDescription(primaryProduct); %>
-          <% if (displayDescription) { %>
-            <p class="detail"><%= displayDescription %></p>
-          <% } %>
-
-          <div class="purchase-row">
-            <input
-              class="quantity-field"
-              type="number"
-              min="1"
-              value="1"
-              aria-label="Menge für <%= group.displayName %>"
-            />
-            <button class="add-btn"
-              data-id="<%= primaryProduct.id %>"
-              data-name="<%= group.displayName %>"
-              data-price="<%= primaryProduct.price %>"
-              data-image="<%= primaryProduct.imageUrl %>"
-              data-color="<%= primaryProduct.color %>">
-              In den Warenkorb
-            </button>
-          </div>
-
-          <a class="btn btn-ghost" style="margin-top:12px; width:100%; justify-content:center;" href="/merch-shop/<%= primaryProduct.slug || primaryProduct.id %>">Produkt ansehen</a>
+        <div class="merch-card-overlay">
+          <span class="merch-card-category"><%= primaryProduct.category %></span>
+          <h2 class="merch-card-name"><%= group.displayName %></h2>
+          <span class="merch-card-price"><%= parseFloat(primaryProduct.price).toLocaleString("de-DE", { style: "currency", currency: "EUR" }) %></span>
         </div>
-      </article>
+      </a>
     <% }) %>
   </div>
 </div>
 
 <script>
-  document.querySelectorAll(".card").forEach(card => {
-    card.addEventListener("click", (event) => {
-      if (event.target.closest("a, button, input, select, label")) return;
-      if (card.dataset.detailUrl) {
-        window.location.href = card.dataset.detailUrl;
-      }
-    });
-  });
-
-  document.querySelectorAll(".add-btn").forEach(btn => {
-    btn.addEventListener("click", async () => {
-      const originalText = btn.textContent;
-      const card = btn.closest(".card");
-      const quantityInput = card.querySelector(".quantity-field");
-      const quantity = Math.max(1, parseInt(quantityInput.value, 10) || 1);
-
-      quantityInput.value = quantity;
-      btn.disabled = true;
-      quantityInput.disabled = true;
-
-      try {
-        const response = await fetch("/api/cart/items", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            type: "merch",
-            name: btn.dataset.name.trim(),
-            price: parseFloat(btn.dataset.price),
-            imageUrl: btn.dataset.image,
-            quantity,
-            details: {
-              productId: parseInt(btn.dataset.id, 10),
-              color: btn.dataset.color,
-            },
-          }),
-        });
-
-        if (response.ok) {
-          btn.textContent = `✓ ${quantity} hinzugefügt`;
-          btn.classList.add("success");
-          setTimeout(() => {
-            btn.textContent = originalText;
-            btn.classList.remove("success");
-            btn.disabled = false;
-            quantityInput.disabled = false;
-          }, 2000);
-        } else {
-          btn.textContent = "Fehler";
-          btn.disabled = false;
-          quantityInput.disabled = false;
-        }
-      } catch (error) {
-        btn.textContent = "Fehler";
-        btn.disabled = false;
-        quantityInput.disabled = false;
-      }
-    });
-  });
-
-  // Scroll to a specific product when arriving via hash link from the AI feature
   if (location.hash) {
     const target = document.querySelector(location.hash);
     if (target) {
       setTimeout(() => {
         target.scrollIntoView({ behavior: "smooth", block: "center" });
-        target.style.transition = "box-shadow 0.3s";
-        target.style.boxShadow = "0 0 0 3px var(--accent)";
-        setTimeout(() => { target.style.boxShadow = ""; }, 1800);
+        target.style.outline = "3px solid var(--accent)";
+        target.style.borderRadius = "12px";
+        setTimeout(() => { target.style.outline = ""; }, 1800);
       }, 100);
     }
   }


### PR DESCRIPTION
- Merch overview: full-bleed image cards with gradient overlay and hover zoom; removed cart functionality (selection only possible on detail page)
- Product detail: open editorial layout with full-cover image, sticky info panel, buttons pushed to bottom via flex; footer hidden on initial load via viewport-height-based image height