### PR TITLE
Polish configurator summary navigation

### DIFF
--- a/web/views/car-configurator.ejs
+++ b/web/views/car-configurator.ejs
@@ -41,14 +41,7 @@
     box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
     backdrop-filter: blur(18px);
     -webkit-backdrop-filter: blur(18px);
-    transition: opacity 0.24s ease, transform 0.24s ease, visibility 0.24s ease;
-  }
-
-  body.summary-nav-collapsed .site-nav--solid {
-    opacity: 0;
-    pointer-events: none;
-    transform: translate(-50%, -14px);
-    visibility: hidden;
+    transition: transform 0.24s ease;
   }
 
   .config-background {
@@ -243,21 +236,25 @@
   .config-btn,
   .option-btn {
     width: 100%;
-    min-height: 48px;
-    padding: 12px 14px;
+    min-height: 54px;
+    padding: 15px 18px;
     border: 1px solid rgba(17, 24, 39, 0.14);
     border-radius: var(--radius-md);
     background: rgba(255, 255, 255, 0.84);
     font-weight: 700;
     cursor: pointer;
-    transition: 0.2s;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
     font-family: inherit;
     color: var(--ink);
+    text-align: center;
   }
 
   .config-btn:hover,
   .option-btn:hover {
     border-color: #111827;
+    background: #fff;
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
+    transform: translateY(-1px);
   }
 
   .config-btn.active,
@@ -265,7 +262,7 @@
     background: #111827;
     color: #fff;
     border-color: #111827;
-    box-shadow: none;
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.12), 0 14px 32px rgba(15, 23, 42, 0.18);
   }
 
   .color-group {
@@ -280,18 +277,27 @@
     gap: 10px;
     width: 100%;
     box-sizing: border-box;
-    min-height: 44px;
-    padding: 7px 12px 7px 7px;
+    min-height: 54px;
+    padding: 10px 14px 10px 10px;
     border: 1px solid rgba(17, 24, 39, 0.14);
     border-radius: var(--radius-md);
     cursor: pointer;
-    transition: 0.2s;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
     background: rgba(255, 255, 255, 0.84);
+  }
+
+  .swatch-wrapper:hover {
+    border-color: #111827;
+    background: #fff;
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
+    transform: translateY(-1px);
   }
 
   .swatch-wrapper.active {
     border-color: #111827;
-    box-shadow: inset 0 -3px 0 #1c69d4;
+    background: rgba(17, 24, 39, 0.94);
+    color: #fff;
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.12), 0 14px 32px rgba(15, 23, 42, 0.18);
   }
 
   .swatch {
@@ -310,8 +316,9 @@
 
   .summary-grid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0;
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 0.9fr) minmax(0, 1fr) minmax(0, 1.45fr);
+    gap: 10px;
+    min-width: 0;
   }
 
   .summary-row {
@@ -319,12 +326,10 @@
     flex-direction: column;
     align-items: flex-start;
     justify-content: center;
-    gap: 4px;
-    padding: 0 18px;
-    border-top: 0;
-    border-left: 0;
-    border-right: 1px solid var(--summary-panel-divider);
-    border-bottom: 0;
+    gap: 7px;
+    min-height: 66px;
+    padding: 12px 14px;
+    border: 1px solid transparent;
     appearance: none;
     background: transparent;
     color: inherit;
@@ -332,25 +337,25 @@
     font: inherit;
     min-width: 0;
     text-align: left;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
   }
 
   .summary-row:hover {
-    background: rgba(28, 105, 212, 0.08);
-  }
-
-  .summary-row:last-child {
-    border-right: none;
+    background: rgba(255, 255, 255, 0.24);
+    border-color: rgba(17, 24, 39, 0.12);
   }
 
   .summary-row.active {
-    background: rgba(17, 24, 39, 0.14);
+    background: rgba(17, 24, 39, 0.08);
+    color: var(--summary-panel-text);
+    border-color: rgba(17, 24, 39, 0.16);
     border-radius: var(--radius-md);
-    box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.42), 0 10px 24px rgba(15, 23, 42, 0.08);
   }
 
   .summary-key {
-    color: var(--summary-panel-muted);
+    color: inherit;
+    opacity: 0.72;
     font-size: 0.86rem;
     font-weight: 800;
     text-shadow: var(--summary-panel-text-shadow);
@@ -359,20 +364,58 @@
 
   .summary-value {
     color: var(--summary-panel-text);
-    font-size: clamp(0.58rem, 0.74vw, 0.82rem);
+    font-size: clamp(0.68rem, 0.76vw, 0.84rem);
     font-weight: 900;
     max-width: 100%;
     text-align: left;
     text-shadow: var(--summary-panel-text-shadow);
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .summary-badge {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    min-height: 28px;
+    padding: 5px 10px;
+    border-radius: 999px;
+    background: rgba(17, 24, 39, 0.1);
+    border: 1px solid rgba(17, 24, 39, 0.12);
+    line-height: 1.1;
+  }
+
+  .summary-badge.is-placeholder {
+    color: var(--summary-panel-muted);
+    background: rgba(255, 255, 255, 0.18);
+    border-style: dashed;
+    font-weight: 800;
+  }
+
+  .summary-row.active .summary-badge {
+    background: rgba(17, 24, 39, 0.1);
+    border-color: rgba(17, 24, 39, 0.16);
+  }
+
+  .summary-row.active .summary-badge.is-placeholder {
+    color: var(--summary-panel-muted);
+  }
+
+  .summary-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 14px;
+    min-width: 260px;
+    padding-left: 20px;
+    border-left: 1px solid var(--summary-panel-divider);
   }
 
   .price-tag {
     display: flex;
     flex-direction: column;
-    min-width: 120px;
-    padding-left: 14px;
-    border-left: 1px solid var(--summary-panel-divider);
+    min-width: 104px;
     text-align: right;
     gap: 4px;
   }
@@ -388,10 +431,11 @@
 
   .price-main {
     color: var(--summary-panel-text);
-    font-size: clamp(0.72rem, 0.9vw, 0.9rem);
+    font-size: clamp(0.86rem, 1vw, 1.02rem);
     font-weight: 800;
     line-height: 1.35;
     text-shadow: var(--summary-panel-text-shadow);
+    white-space: nowrap;
   }
 
   .add-btn {
@@ -400,7 +444,7 @@
     padding: 0 18px;
     border-radius: var(--radius-md);
     border: none;
-    background: #1c69d4;
+    background: #2d74d8;
     color: #fff;
     font-size: 0.98rem;
     font-weight: 700;
@@ -408,6 +452,25 @@
     transition: 0.2s;
     margin-top: 18px;
     font-family: inherit;
+  }
+
+  .summary-add-btn {
+    width: auto;
+    min-width: 128px;
+    min-height: 46px;
+    border-radius: 999px;
+    margin-top: 0;
+    padding: 0 20px;
+    white-space: nowrap;
+    box-shadow: 0 10px 22px rgba(45, 116, 216, 0.18);
+  }
+
+  .summary-action-control {
+    position: relative;
+    display: grid;
+    place-items: center;
+    align-items: center;
+    min-width: 164px;
   }
 
   .summary-panel {
@@ -427,15 +490,10 @@
     border-radius: var(--radius);
     box-shadow: 0 18px 60px rgba(15, 23, 42, 0.08);
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(120px, auto);
-    gap: 14px;
+    grid-template-columns: minmax(0, 1fr) minmax(260px, auto);
+    gap: 20px;
     align-items: center;
     transition: top 0.24s ease, background 0.25s ease, border-color 0.25s ease, color 0.25s ease;
-  }
-
-  body.summary-nav-collapsed .summary-panel {
-    top: var(--config-nav-top);
-    z-index: 10;
   }
 
   .summary-panel[data-contrast="dark"] {
@@ -460,26 +518,25 @@
     min-width: 0;
   }
 
-  .completion-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-  }
-
-  .completion-panel .add-btn {
-    margin-top: 0;
-  }
-
   .completion-status {
-    min-height: 20px;
-    color: #10b981;
-    font-weight: 700;
+    position: absolute;
+    top: calc(100% + 14px);
+    left: 50%;
+    min-height: 0;
+    min-width: max-content;
+    transform: translateX(-50%);
+    color: #047857;
+    font-weight: 400;
     text-align: center;
+    font-size: 0.72rem;
+    line-height: 1.2;
+    max-width: 100%;
   }
 
   @media (max-width: 760px) {
     :root {
-      --summary-bar-height: 184px;
+      --config-nav-height: 160px;
+      --summary-bar-height: 286px;
     }
 
     .summary-panel {
@@ -489,34 +546,62 @@
       gap: 10px;
     }
 
-    .price-tag {
+    .summary-actions {
+      align-items: stretch;
       min-width: 0;
       padding-left: 0;
-      padding-bottom: 10px;
+      padding-top: 10px;
       border-left: 0;
-      border-bottom: 1px solid var(--summary-panel-divider);
+      border-top: 1px solid var(--summary-panel-divider);
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 10px;
+    }
+
+    .price-tag {
+      min-width: 0;
       text-align: left;
+    }
+
+    .summary-add-btn {
+      width: 100%;
+      min-width: 0;
+      min-height: 44px;
+      padding: 0 16px;
+    }
+
+    .summary-action-control {
+      position: relative;
+      min-width: 0;
+    }
+
+    .completion-status {
+      grid-column: 1 / -1;
+      max-width: none;
+      text-align: center;
     }
 
     .summary-grid {
       grid-template-columns: 1fr;
+      gap: 6px;
     }
 
     .summary-row {
-      min-height: 24px;
-      padding: 3px 0;
+      min-height: 40px;
+      padding: 8px 10px;
       border-right: 0;
-      border-bottom: 1px solid var(--summary-panel-divider);
+      border-bottom: 0;
     }
 
-    .summary-row:last-child {
-      border-bottom: none;
+    .summary-badge {
+      min-height: 24px;
+      padding: 4px 8px;
     }
 
   }
 
   .add-btn:hover:not(:disabled) {
-    background: #1554ad;
+    background: #245fb1;
     transform: translateY(-1px);
   }
 
@@ -536,25 +621,31 @@
   <div class="summary-grid">
     <button class="summary-row" type="button" data-summary-section="model">
       <div class="summary-key">Modell</div>
-      <div class="summary-value" id="selectedModel"></div>
+      <div class="summary-value summary-badge is-placeholder" id="selectedModel">Auswählen</div>
     </button>
     <button class="summary-row" type="button" data-summary-section="exterior">
       <div class="summary-key">Exterieur</div>
-      <div class="summary-value" id="selectedColor"></div>
+      <div class="summary-value summary-badge is-placeholder" id="selectedColor">Auswählen</div>
     </button>
     <button class="summary-row" type="button" data-summary-section="interior">
       <div class="summary-key">Interieur</div>
-      <div class="summary-value" id="selectedInterior"></div>
+      <div class="summary-value summary-badge is-placeholder" id="selectedInterior">Auswählen</div>
     </button>
     <button class="summary-row" type="button" data-summary-section="wheels">
       <div class="summary-key">Felgen</div>
-      <div class="summary-value" id="selectedWheels"></div>
+      <div class="summary-value summary-badge is-placeholder" id="selectedWheels">Auswählen</div>
     </button>
   </div>
 
-  <div class="price-tag">
-    <span>Preis</span>
-    <div class="price-main" id="price">0,00 EUR</div>
+  <div class="summary-actions">
+    <div class="price-tag">
+      <span>Preis</span>
+      <div class="price-main" id="price">0,00 EUR</div>
+    </div>
+    <div class="summary-action-control">
+      <button class="add-btn summary-add-btn" type="button" data-add-config disabled>Abschließen</button>
+      <div class="completion-status" data-add-status></div>
+    </div>
   </div>
 </div>
 
@@ -582,11 +673,6 @@
         <div class="option-group" id="wheelsBtns"></div>
       </section>
 
-      <section class="panel config-options-panel completion-panel" data-view="wheels" data-summary-target="">
-        <h1>Konfiguration abschließen</h1>
-        <button class="add-btn" type="button" data-add-config disabled>Konfiguration abschließen</button>
-        <div class="completion-status" data-add-status></div>
-      </section>
     </div>
 
   </div>
@@ -874,10 +960,6 @@
     });
   }
 
-  function setSummaryNavCollapsed(collapsed) {
-    document.body.classList.toggle("summary-nav-collapsed", collapsed);
-  }
-
   function initializeConfigPanelScroll() {
     const stack = document.getElementById("configPanelStack");
     const panels = Array.from(document.querySelectorAll(".config-options-panel"));
@@ -946,14 +1028,8 @@
       const now = Date.now();
       if (now - lastSwitchAt < 720) return;
       const nextIndex = activeIndex + direction;
-      if (nextIndex < 0) {
-        setSummaryNavCollapsed(false);
-        return;
-      }
+      if (nextIndex < 0) return;
       if (nextIndex >= panels.length) return;
-      if (direction > 0) {
-        setSummaryNavCollapsed(true);
-      }
       lastSwitchAt = now;
       activatePanel(nextIndex, direction);
     }
@@ -962,7 +1038,6 @@
       if (!target || isAnimating) return;
       const nextIndex = panels.findIndex((panel) => panel.dataset.summaryTarget === target);
       if (nextIndex < 0 || nextIndex === activeIndex) return;
-      setSummaryNavCollapsed(true);
       lastSwitchAt = Date.now();
       activatePanel(nextIndex, nextIndex > activeIndex ? 1 : -1);
     }
@@ -1023,7 +1098,6 @@
     window.addEventListener("touchend", handlePageTouchEnd, { passive: true });
 
     activatePanel(activeIndex);
-    setSummaryNavCollapsed(true);
   }
 
   async function fetchOptionsForModel(modelId) {
@@ -1250,6 +1324,14 @@
     }
   }
 
+  function setSummaryBadge(id, value) {
+    const badge = document.getElementById(id);
+    if (!badge) return;
+    const hasValue = Boolean(value);
+    badge.textContent = hasValue ? value : "Auswählen";
+    badge.classList.toggle("is-placeholder", !hasValue);
+  }
+
   function updateUI() {
     const cfg = state.config;
     const img = document.getElementById("carImg");
@@ -1257,11 +1339,11 @@
     const addButtons = document.querySelectorAll("[data-add-config]");
 
     if (!cfg) {
-      document.getElementById("selectedModel").textContent = "";
+      setSummaryBadge("selectedModel", "");
       document.getElementById("price").textContent = "Nicht verfügbar";
-      document.getElementById("selectedColor").textContent = "";
-      document.getElementById("selectedInterior").textContent = "";
-      document.getElementById("selectedWheels").textContent = "";
+      setSummaryBadge("selectedColor", "");
+      setSummaryBadge("selectedInterior", "");
+      setSummaryBadge("selectedWheels", "");
       addButtons.forEach((button) => { button.disabled = true; });
       img.style.display = "none";
       placeholder.style.display = "block";
@@ -1270,14 +1352,11 @@
       return;
     }
 
-    document.getElementById("selectedModel").textContent = state.summaryTouched.model ? displayText(cfg.model.name) : "";
     document.getElementById("price").textContent = formatPrice(cfg.totalPrice);
-    document.getElementById("selectedColor").textContent =
-      state.summaryTouched.exterior && cfg.color ? displayColorName(cfg.color.name) : "";
-    document.getElementById("selectedInterior").textContent =
-      state.summaryTouched.interior && cfg.interior ? displayText(cfg.interior.name) : "";
-    document.getElementById("selectedWheels").textContent =
-      state.summaryTouched.wheels && cfg.wheels ? displayText(cfg.wheels.name) : "";
+    setSummaryBadge("selectedModel", cfg.model ? displayText(cfg.model.name) : "");
+    setSummaryBadge("selectedColor", cfg.color ? displayColorName(cfg.color.name) : "");
+    setSummaryBadge("selectedInterior", cfg.interior ? displayText(cfg.interior.name) : "");
+    setSummaryBadge("selectedWheels", cfg.wheels ? displayText(cfg.wheels.name) : "");
 
     addButtons.forEach((button) => { button.disabled = false; });
     updateSummaryContrast(cfg);
@@ -1357,6 +1436,5 @@
     button.addEventListener("click", addConfigurationToCart);
   });
 
-  setSummaryNavCollapsed(true);
   loadInitialData();
 </script>


### PR DESCRIPTION
## Summary
- keep the shared navigator visible on the configurator page
- show current selections as summary badges in the configurator summary bar
- move and polish the Abschließen action and transient success message

## Scope
This PR is intentionally limited to one tracked file: web/views/car-configurator.ejs.

## Validation
- `npm test` in services/web-shop-backend: 7/7 passed
- browser-checked http://127.0.0.1:3000/car-configurator during implementation
